### PR TITLE
refactor(db): 为 getArticleDetail 函数添加 client_type 参数

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -18,6 +18,7 @@ export async function getArticleDetail(article_id: string) {
     "https://api.juejin.cn/content_api/v1/article/detail",
     {
       article_id,
+      client_type: 2608,
     }
   );
 


### PR DESCRIPTION
- 在 getArticleDetail 函数中添加 client_type 参数，设置为 2608。
- 解决文章接口获取失败的问题。